### PR TITLE
darwin.txt: add iCloud hosts

### DIFF
--- a/darwin.txt
+++ b/darwin.txt
@@ -141,6 +141,10 @@ iwork.apple.com
 mask.icloud.com
 mask-h2.icloud.com
 mask-api.icloud.com
+probe.icloud.com
+pong.icloud.com
+metrics.icloud.com
+apple-native-relay.apple.com
 
 # Apple Intelligence, Siri and Search
 guzzoni.apple.com


### PR DESCRIPTION
These changes correspond to Recent changes > January 2026 on Apple's documentation page listed in the file.

Updates ZenPrivacy/zen-desktop#624
